### PR TITLE
Add Ecodim 05 Zigbee Double dimmer switch

### DIFF
--- a/zhaquirks/hzc/doubledimmerswitch.py
+++ b/zhaquirks/hzc/doubledimmerswitch.py
@@ -1,0 +1,126 @@
+"""Quirk for EcoDim 05 two gang dimmer (e.g. HZC Smart Double Dimmer D686-ZG)."""
+
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks import NoReplyMixin
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class HzcOnOff(NoReplyMixin, CustomCluster, OnOff):
+    """HZC On Off Cluster."""
+
+    void_input_commands = {cmd.id for cmd in OnOff.commands_by_name.values()}
+
+
+class DoubleDimmerSwitch(CustomDevice):
+    """Double Dimmer-Switch-ZB3.0 by EcoDim / HZC / Shyugj."""
+
+    signature = {
+        MODELS_INFO: [
+            ("EcoDim BV", "EcoDim-Zigbee 3.0"),
+        ],
+        ENDPOINTS: {
+            1: {
+                # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+                # input_clusters=[0, 3, 4, 5, 6, 8, 4096]
+                # output_clusters=[25]>
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+                # input_clusters=[0, 3, 4, 5, 6, 8, 4096]
+                # output_clusters=[25]>
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    HzcOnOff,  # OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    HzcOnOff,  # OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
Note that the Ecodim 05 Zigbee is an HZC D686-ZG LED dimmer. This change was inspired by #3326 and fixes #2865 and https://community.home-assistant.io/t/eco-dim-05-dual-dimmer-not-supported-in-zha/623843

## Proposed change
<!--
  Add a quirk that ignores the respons when turning the dimmer on of off (as a response will never come)
-->


## Additional information
<!--
  Fixes #2865 and is inspired on #3326
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
